### PR TITLE
#charset-binaries-fix prevent run server without binaries. Added defa…

### DIFF
--- a/mdlight/index/pages.py
+++ b/mdlight/index/pages.py
@@ -15,7 +15,7 @@ _log = logging.getLogger(__name__)
 
 
 class IPage(object):
-    mime_type_ = "text/html"
+    mime_type_ = "text/html;charset=utf-8"
     encoding_ = None
     title_ = None
 
@@ -46,8 +46,10 @@ class MarkdownPage(IPage):
         return title
 
     ACCEPTED_EXTENSIONS = {".markdown", ".md", ".tex"}
+    BINARY_NAME = "pandoc"
 
     def __init__(self, filepath):
+        super(MarkdownPage, self).__init__()
         _log.debug("Markdown node %r", filepath)
         self.filepath = filepath
         self.title_ = self._extract_title(filepath)
@@ -55,7 +57,7 @@ class MarkdownPage(IPage):
 
     def content(self):
         proc = subprocess.Popen(
-            ["pandoc", self.filepath, "--to", "html5"],
+            [self.BINARY_NAME, self.filepath, "--to", "html5"],
             shell=False,
             stdout=subprocess.PIPE,
         )
@@ -69,8 +71,10 @@ class GraphvizPage(IPage):
         ".graphviz",
         ".dot",
     }
+    BINARY_NAME = "dot"
 
     def __init__(self, filepath):
+        super(GraphvizPage).__init__()
         _log.debug("Graphviz node %r", filepath)
         self.filepath = filepath
         self.title_ = os.path.basename(filepath)
@@ -79,7 +83,7 @@ class GraphvizPage(IPage):
 
     def content(self):
         proc = subprocess.Popen(
-            ["dot", self.filepath, "-T", "svg"],
+            [self.BINARY_NAME , self.filepath, "-T", "svg"],
             shell=False,
             stdout=subprocess.PIPE,
         )
@@ -95,6 +99,7 @@ class IndexPage(IPage):
             self.path = path
 
     def __init__(self, path):
+        super(IndexPage, self).__init__()
         _log.debug("Index page %r", path)
         self.path = path
         self.items = list()
@@ -122,6 +127,7 @@ class IndexPage(IPage):
 
 class StaticPage(IPage):
     def __init__(self, path):
+        super(StaticPage).__init__()
         _log.debug("Static page %r", path)
         self.path = path
         self.title_ = os.path.basename(path)

--- a/mdlight/index/pages.py
+++ b/mdlight/index/pages.py
@@ -16,7 +16,7 @@ _log = logging.getLogger(__name__)
 
 class IPage(object):
     mime_type_ = "text/html;charset=utf-8"
-    encoding_ = None
+    encoding_ = "identity"
     title_ = None
 
     def content_type(self):
@@ -52,7 +52,6 @@ class MarkdownPage(IPage):
         _log.debug("Markdown node %r", filepath)
         self.filepath = filepath
         self.title_ = self._extract_title(filepath)
-        self.encoding_ = "utf-8"
 
     def content(self):
         proc = subprocess.Popen(
@@ -76,7 +75,6 @@ class GraphvizPage(IPage):
         _log.debug("Graphviz node %r", filepath)
         self.filepath = filepath
         self.title_ = os.path.basename(filepath)
-        self.encoding_ = "utf-8"
         self.mime_type_ = "image/svg+xml"
 
     def content(self):

--- a/mdlight/index/pages.py
+++ b/mdlight/index/pages.py
@@ -49,7 +49,6 @@ class MarkdownPage(IPage):
     BINARY_NAME = "pandoc"
 
     def __init__(self, filepath):
-        super(MarkdownPage, self).__init__()
         _log.debug("Markdown node %r", filepath)
         self.filepath = filepath
         self.title_ = self._extract_title(filepath)
@@ -74,7 +73,6 @@ class GraphvizPage(IPage):
     BINARY_NAME = "dot"
 
     def __init__(self, filepath):
-        super(GraphvizPage).__init__()
         _log.debug("Graphviz node %r", filepath)
         self.filepath = filepath
         self.title_ = os.path.basename(filepath)
@@ -99,7 +97,6 @@ class IndexPage(IPage):
             self.path = path
 
     def __init__(self, path):
-        super(IndexPage, self).__init__()
         _log.debug("Index page %r", path)
         self.path = path
         self.items = list()
@@ -127,7 +124,6 @@ class IndexPage(IPage):
 
 class StaticPage(IPage):
     def __init__(self, path):
-        super(StaticPage).__init__()
         _log.debug("Static page %r", path)
         self.path = path
         self.title_ = os.path.basename(path)

--- a/mdlight/server.py
+++ b/mdlight/server.py
@@ -4,6 +4,7 @@
 This is a simplest markdown document viewer.
 
 It scan {--dir} directory for markdown documents and run http server on it.
+If not $MDLIGHT_DIR specified - current directory chosed by default.
 To see documents just open any web-browser and got to
 "http://{--host}:{--port}" website.
 """
@@ -27,6 +28,21 @@ sys.path.append(
 
 
 import mdlight.index.tree
+from mdlight.index.pages import MarkdownPage, GraphvizPage
+
+
+_REQUIRED_BINARIES = [
+    MarkdownPage.BINARY_NAME,
+    GraphvizPage.BINARY_NAME,
+]
+
+
+def __check_binary(binary):
+    for path in os.environ["PATH"].split(os.pathsep):
+        full_path = os.path.join(path, binary)
+        if os.path.exists(full_path):
+            return True
+    return False
 
 
 _log = logging.getLogger(__name__)
@@ -39,7 +55,7 @@ def parse_args():
     parser.add_argument(
         "--dir",
         metavar="PATH",
-        default=os.curdir,
+        default=os.path.expanduser(os.environ.get("MDLIGHT_DIR", os.curdir)),
         help="Directory with markdown pages, default: %(default)s.",
     )
     parser.add_argument(
@@ -96,6 +112,13 @@ def main():
 
 if __name__ == "__main__":
     try:
+        for binary in _REQUIRED_BINARIES:
+            if not __check_binary(binary):
+                raise Exception(
+                    "%s is not installed, or not in a PATH env" %
+                    binary
+                )
+
         _log = logging.getLogger(__name__)
         _log.setLevel(logging.DEBUG)
 


### PR DESCRIPTION
- [x] added default env = $MDLIGHT_DIR which is relative (can use '~')
- [x] fixed encoding issue [documentation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Encoding)
- [x] fixed server run without installed requirements, like graphviz or pandoc
