### PR TITLE
#charset-binaries-fix prevent run server without binaries. Added defa…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ nosetests.xml
 coverage.xml
 *.cover
 .hypothesis/
+.pytest_cache/
 
 # Translations
 *.mo

--- a/mdlight/index/pages.py
+++ b/mdlight/index/pages.py
@@ -15,8 +15,8 @@ _log = logging.getLogger(__name__)
 
 
 class IPage(object):
-    mime_type_ = "text/html"
-    encoding_ = None
+    mime_type_ = "text/html;charset=utf-8"
+    encoding_ = "identity"
     title_ = None
 
     def content_type(self):
@@ -46,16 +46,16 @@ class MarkdownPage(IPage):
         return title
 
     ACCEPTED_EXTENSIONS = {".markdown", ".md", ".tex"}
+    BINARY_NAME = "pandoc"
 
     def __init__(self, filepath):
         _log.debug("Markdown node %r", filepath)
         self.filepath = filepath
         self.title_ = self._extract_title(filepath)
-        self.encoding_ = "utf-8"
 
     def content(self):
         proc = subprocess.Popen(
-            ["pandoc", self.filepath, "--to", "html5"],
+            [self.BINARY_NAME, self.filepath, "--to", "html5"],
             shell=False,
             stdout=subprocess.PIPE,
         )
@@ -69,17 +69,17 @@ class GraphvizPage(IPage):
         ".graphviz",
         ".dot",
     }
+    BINARY_NAME = "dot"
 
     def __init__(self, filepath):
         _log.debug("Graphviz node %r", filepath)
         self.filepath = filepath
         self.title_ = os.path.basename(filepath)
-        self.encoding_ = "utf-8"
         self.mime_type_ = "image/svg+xml"
 
     def content(self):
         proc = subprocess.Popen(
-            ["dot", self.filepath, "-T", "svg"],
+            [self.BINARY_NAME , self.filepath, "-T", "svg"],
             shell=False,
             stdout=subprocess.PIPE,
         )

--- a/mdlight/index/pages.py
+++ b/mdlight/index/pages.py
@@ -16,7 +16,7 @@ _log = logging.getLogger(__name__)
 
 class IPage(object):
     mime_type_ = "text/html;charset=utf-8"
-    encoding_ = "identity"
+    encoding_ = None
     title_ = None
 
     def content_type(self):
@@ -52,6 +52,7 @@ class MarkdownPage(IPage):
         _log.debug("Markdown node %r", filepath)
         self.filepath = filepath
         self.title_ = self._extract_title(filepath)
+        self.encoding_ = "identity"
 
     def content(self):
         proc = subprocess.Popen(

--- a/mdlight/server.py
+++ b/mdlight/server.py
@@ -4,6 +4,7 @@
 This is a simplest markdown document viewer.
 
 It scan {--dir} directory for markdown documents and run http server on it.
+If not $MDLIGHT_DIR specified - current directory chosed by default.
 To see documents just open any web-browser and got to
 "http://{--host}:{--port}" website.
 """
@@ -27,6 +28,21 @@ sys.path.append(
 
 
 import mdlight.index.tree
+from mdlight.index.pages import MarkdownPage, GraphvizPage
+
+
+_REQUIRED_BINARIES = [
+    MarkdownPage.BINARY_NAME,
+    GraphvizPage.BINARY_NAME,
+]
+
+
+def __check_binary(binary):
+    for path in os.environ["PATH"].split(os.pathsep):
+        full_path = os.path.join(path, binary)
+        if os.path.exists(full_path):
+            return True
+    return False
 
 
 _log = logging.getLogger(__name__)
@@ -39,7 +55,7 @@ def parse_args():
     parser.add_argument(
         "--dir",
         metavar="PATH",
-        default=os.curdir,
+        default=os.path.expanduser(os.environ.get("MDLIGHT_DIR", os.curdir)),
         help="Directory with markdown pages, default: %(default)s.",
     )
     parser.add_argument(
@@ -96,6 +112,13 @@ def main():
 
 if __name__ == "__main__":
     try:
+        for binary in _REQUIRED_BINARIES:
+            if not __check_binary(binary):
+                raise Exception(
+                    "%s is not installed, or not in a PATH env" %
+                    binary
+                )
+
         _log = logging.getLogger(__name__)
         _log.setLevel(logging.DEBUG)
 

--- a/mdlight/server.py
+++ b/mdlight/server.py
@@ -4,18 +4,18 @@
 This is a simplest markdown document viewer.
 
 It scan {--dir} directory for markdown documents and run http server on it.
-If not $MDLIGHT_DIR specified - current directory chosed by default.
 To see documents just open any web-browser and got to
 "http://{--host}:{--port}" website.
 """
 
-from http import HTTPStatus
 import argparse
 import http.server
 import logging
 import os
 import re
 import sys
+from http import HTTPStatus
+from shutil import which
 
 
 sys.path.append(
@@ -37,12 +37,10 @@ _REQUIRED_BINARIES = [
 ]
 
 
-def __check_binary(binary):
-    for path in os.environ["PATH"].split(os.pathsep):
-        full_path = os.path.join(path, binary)
-        if os.path.exists(full_path):
-            return True
-    return False
+def _check_binaries(binaries_name):
+    for binary_name in binaries_name:
+        if not which(binary_name):
+            raise FileNotFoundError("Can not find %s" % binary_name)
 
 
 _log = logging.getLogger(__name__)
@@ -55,7 +53,7 @@ def parse_args():
     parser.add_argument(
         "--dir",
         metavar="PATH",
-        default=os.path.expanduser(os.environ.get("MDLIGHT_DIR", os.curdir)),
+        default=os.curdir,
         help="Directory with markdown pages, default: %(default)s.",
     )
     parser.add_argument(
@@ -112,12 +110,8 @@ def main():
 
 if __name__ == "__main__":
     try:
-        for binary in _REQUIRED_BINARIES:
-            if not __check_binary(binary):
-                raise Exception(
-                    "%s is not installed, or not in a PATH env" %
-                    binary
-                )
+
+        _check_binaries(_REQUIRED_BINARIES)
 
         _log = logging.getLogger(__name__)
         _log.setLevel(logging.DEBUG)


### PR DESCRIPTION
- [x] added default env = $MDLIGHT_DIR which is relative (can use '~')
- [x] fixed encoding issue [documentation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Encoding)
- [x] fixed server run without installed requirements, like graphviz or pandoc
